### PR TITLE
add option to use losses either from torch.nn or from torch.nn.functional

### DIFF
--- a/fsaa/attack.py
+++ b/fsaa/attack.py
@@ -87,8 +87,8 @@ def attack(
     mask = None if perceptual_mask is None else perceptual_mask(x).detach()
 
     # Performing attack
-    best_loss = float("inf")
-    best_adv = x_adv
+    best_loss = torch.tensor([float("inf")] * len(x)).to(device)
+    best_adv = x_adv.detach()
     bar = range(steps) if not pbar else tqdm(
         range(steps), desc="Attack", leave=False)
     for step in bar:
@@ -97,10 +97,12 @@ def attack(
         features = model(x_adv)
 
         # Computing the gradient w.r.t loss
-        i_loss = 0 if ilw == 0 else ilw * image_loss(x_adv, x).mean()
-        f_loss = 0 if flw == 0 else flw * feature_loss(features, labels).mean()
+        i_loss = 0 if ilw == 0 else ilw * \
+            image_loss(x_adv, x).mean(dim=list(range(1, x.ndim)))
+        f_loss = 0 if flw == 0 else flw * \
+            feature_loss(features, labels).mean(dim=1)
         loss = f_loss + i_loss
-        grad = torch.autograd.grad(loss, x_adv)[0]
+        grad = torch.autograd.grad(loss.mean(), x_adv)[0]
 
         if torch.all(grad == 0):
             warn("Gradient is zero. Stopping attack.")
@@ -110,13 +112,14 @@ def attack(
         if mask is not None:
             grad = mask * grad
 
-        # Storing best perturbation
-        if best_loss > loss and (ilw == 0 or i_loss / ilw <= max_img_loss):
-            best_loss = loss
-            best_adv = x_adv.clone().detach()
-
         # Updating perturbation
         x_adv = updater(x_adv.detach(), grad, step, steps, loss)
         x_adv = torch.clamp(x_adv, min=0, max=1).detach()
+
+        # Storing best perturbation
+        update_best = torch.bitwise_and(
+            loss < best_loss, ilw == 0 or i_loss / ilw <= max_img_loss)
+        best_loss[update_best] = loss[update_best].detach()
+        best_adv[update_best] = x_adv[update_best].clone().detach()
 
     return best_adv

--- a/fsaa/losses/lpips_loss.py
+++ b/fsaa/losses/lpips_loss.py
@@ -13,7 +13,7 @@ class LPIPSAlexLoss(Module):
     def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         """Computes the LPIPS loss between two tensors x and y.
         Both tensors should be normalized in range [0, 1]."""
-        return self.net(x, y, normalize=True).mean()
+        return self.net(x, y, normalize=True)
 
 
 class LPIPSVGGLoss(Module):
@@ -26,4 +26,4 @@ class LPIPSVGGLoss(Module):
     def forward(self, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
         """Computes the LPIPS loss between two tensors x and y.
         Both tensors should be normalized in range [0, 1]."""
-        return self.net(x, y, normalize=True).mean()
+        return self.net(x, y, normalize=True)

--- a/fsaa/losses/mse_loss.py
+++ b/fsaa/losses/mse_loss.py
@@ -5,7 +5,7 @@ from torch.nn import Module, MSELoss
 class MeanSquaredErrorLoss(Module):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.criterion = MSELoss()
+        self.criterion = MSELoss(reduction="none")
 
     def forward(self, x: Tensor, y: Tensor) -> Tensor:
         return self.criterion(x, y)

--- a/fsaa/utils.py
+++ b/fsaa/utils.py
@@ -2,7 +2,6 @@ from typing import Callable
 
 from torch import nn
 from torch.nn import Module
-from torch.nn import functional as F
 
 from fsaa.core import (PerceptualMask, PerturbationInitializer,
                        PerturbationUpdater)
@@ -80,10 +79,10 @@ def get_loss(name: str, **kwargs) -> Callable:
     if name in LOSSES:
         return LOSSES[name](**kwargs)
     if hasattr(nn, name):
+        kwargs.update({"reduction": "none"})
         return getattr(nn, name)(**kwargs)
-    if hasattr(F, name):
-        return getattr(F, name)
-    raise ValueError(f"Loss '{name}' is not supported. Pick one of {LOSSES} or use a loss either from torch.nn or torch.nn.functional")
+    raise ValueError(
+        f"Loss '{name}' is not supported. Pick one of {LOSSES} or use a loss either from torch.nn or torch.nn.functional")
 
 
 def get_mask(name: str, **kwargs) -> PerceptualMask:

--- a/fsaa/utils.py
+++ b/fsaa/utils.py
@@ -1,4 +1,8 @@
+from typing import Callable
+
+from torch import nn
 from torch.nn import Module
+from torch.nn import functional as F
 
 from fsaa.core import (PerceptualMask, PerturbationInitializer,
                        PerturbationUpdater)
@@ -71,9 +75,15 @@ def get_updater(name: str, lr: float, **kwargs) -> PerturbationUpdater:
     return UPDATERS[name](lr, **kwargs)
 
 
-def get_loss(name: str, **kwargs) -> Module:
+def get_loss(name: str, **kwargs) -> Callable:
     """Returns the loss used for the attack."""
-    return LOSSES[name](**kwargs)
+    if name in LOSSES:
+        return LOSSES[name](**kwargs)
+    if hasattr(nn, name):
+        return getattr(nn, name)(**kwargs)
+    if hasattr(F, name):
+        return getattr(F, name)
+    raise ValueError(f"Loss '{name}' is not supported. Pick one of {LOSSES} or use a loss either from torch.nn or torch.nn.functional")
 
 
 def get_mask(name: str, **kwargs) -> PerceptualMask:

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from fsaa.utils import LOSSES, get_loss
+
+
+@pytest.fixture
+def data():
+    shape = (1, 3, 224, 224)
+    return torch.randn(shape).clamp(0, 1), torch.randn(shape).clamp(0, 1)
+
+
+def test_custom_losses():
+    """Tests that the all custom losses return a loss"""
+    for loss_name in LOSSES:
+        loss_fn = get_loss(loss_name)
+        assert callable(loss_fn)
+        assert isinstance(loss_fn, nn.Module)
+
+
+def test_nn_losses(data):
+    x, y = data
+
+    mse_loss = get_loss("MSELoss")
+    assert callable(mse_loss)
+    loss = mse_loss(x, y)
+    assert isinstance(loss, torch.Tensor)
+    assert torch.allclose(loss, nn.MSELoss()(x, y))
+    assert torch.allclose(loss, (x - y).pow(2).mean())
+
+
+def test_functional_losses(data):
+    x, y = data
+
+    mse_loss = get_loss("mse_loss")
+    assert callable(mse_loss)
+    loss = mse_loss(x, y)
+    assert isinstance(loss, torch.Tensor)
+    assert torch.allclose(loss, F.mse_loss(x, y))
+    assert torch.allclose(loss, (x - y).pow(2).mean())

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,7 +1,6 @@
 import pytest
 import torch
 from torch import nn
-from torch.nn import functional as F
 
 from fsaa.utils import LOSSES, get_loss
 
@@ -27,16 +26,5 @@ def test_nn_losses(data):
     assert callable(mse_loss)
     loss = mse_loss(x, y)
     assert isinstance(loss, torch.Tensor)
-    assert torch.allclose(loss, nn.MSELoss()(x, y))
-    assert torch.allclose(loss, (x - y).pow(2).mean())
-
-
-def test_functional_losses(data):
-    x, y = data
-
-    mse_loss = get_loss("mse_loss")
-    assert callable(mse_loss)
-    loss = mse_loss(x, y)
-    assert isinstance(loss, torch.Tensor)
-    assert torch.allclose(loss, F.mse_loss(x, y))
-    assert torch.allclose(loss, (x - y).pow(2).mean())
+    assert torch.allclose(loss.mean(), nn.MSELoss()(x, y))
+    assert torch.allclose(loss.mean(), (x - y).pow(2).mean())


### PR DESCRIPTION
Now it should be easier to play around with different losses available in the `torch` library.  Instead of writing wrappers, it is possible just to provide the name of a loss (e.g., `MSELoss` instead of `fsaa/losses/mse_loss.py` file) 

For the example in the `readme` file, mse in the feature domain is increased by 0.4 and cosine similarity is decreased by 0.007 by utilizing `SmoothL1Loss` (which is not a significant improvement, but more comprehensive testing is needed).

P.S. I couldn't make `pre-commit` hooks work :(